### PR TITLE
add compose file and pip requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM python:3.8.14-slim
 
-WORKDIR /home
+COPY requirements.txt .
+RUN /usr/local/bin/python -m pip install --upgrade pip && pip install -r requirements.txt
 
-RUN /usr/local/bin/python -m pip install --upgrade pip && pip install py-cord==2.0.0b1 python-dotenv requests
+WORKDIR /opt/TF-1726
+COPY elobot/* ./
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git && git clone https://github.com/SogeMoge/TF-1726.git
-
-WORKDIR /home/TF-1726
-
-CMD ["python3", "elobot/main.py"]
+ENTRYPOINT ["python3", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  elobot:
+    image: sogemoge/tf-1726:latest
+    restart: always
+    ports:
+      - 0.0.0.0:8080:800
+    volumes:
+      - type: bind
+        source: ./elo.db
+        target: /opt/TF-1726/elo.db
+      - type: bind
+        source: ./.env
+        target: /opt/TF-1726/.env
+#    healthcheck:
+#      test: ["CMD", "curl", "127.0.0.1"]
+#      interval: 10s
+#      timeout: 5s
+#      retries: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+py-cord==2.0.0b1
+python-dotenv
+requests


### PR DESCRIPTION
Changed Dockerfile structure: copy only needed files instead of full repository clone. pip3 no install modules from requirements.txt
Start bot with docker-compose (restart: always), mount .env and elo.db