### PR TITLE
%20 space fix

### DIFF
--- a/elobot/main.py
+++ b/elobot/main.py
@@ -273,13 +273,15 @@ async def on_message(message):
                     colour=discord.Colour.random(),
                     url=message.content,
                     description="YASB Legacy 2.0 list"
-            else :
-                embed = discord.Embed(
-                    title="Infamous squadron",
-                    colour=discord.Colour.random(),
-                    url=message.content,
-                    description="YASB Legacy 2.0 list" 
                 )
+
+        if not embed:
+            embed = discord.Embed(
+                title="Infamous squadron",
+                colour=discord.Colour.random(),
+                url=message.content,
+                description="YASB Legacy 2.0 list"
+            )
 
         embed.set_footer(
             text=message.author.display_name, icon_url=message.author.display_avatar

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -250,7 +250,7 @@ async def on_message(message):
 
         #############
         # don't know if it works at all???
-        yasb_xws = unescape(yasb_xws) # delete all characters which prevents proper parsing
+        #yasb_xws = unescape(yasb_xws) # delete all characters which prevents proper parsing
 
         yasb_json = yasb_xws.json() # raw XWS in JSON
         yasb_json = json.dumps(yasb_json) # convert single quotes to double quotes

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -273,6 +273,12 @@ async def on_message(message):
                     colour=discord.Colour.random(),
                     url=message.content,
                     description="YASB Legacy 2.0 list"
+            else:
+               embed = discord.Embed(
+                    title="Infamous squadron",
+                    colour=discord.Colour.random(),
+                    url=message.content,
+                    description="YASB Legacy 2.0 list" 
                 )
 
         embed.set_footer(

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -247,24 +247,24 @@ async def on_message(message):
 
         # convert YASB link to XWS
         yasb_link = message.content
-        print(f"1) yasb_link = {yasb_link})
+        print(f"1) yasb_link = {yasb_link}")
         yasb_convert = yasb_link.replace(
             '://xwing-legacy.com/',
             '://squad2xws.herokuapp.com/yasb/xws'
         )
-        print(f"2) yasb_convert = {yasb_convert})
+        print(f"2) yasb_convert = {yasb_convert}")
         yasb_xws = requests.get(yasb_convert, timeout=10)
-        print(f"3) yasb_xws = {yasb_xws})
+        print(f"3) yasb_xws = {yasb_xws}")
         #############
         # don't know if it works at all???
         #yasb_xws = unescape(yasb_xws) # delete all characters which prevents proper parsing
 
         yasb_json = yasb_xws.json() # raw XWS in JSON
-        print(f"4) yasb_json = {yasb_json})
+        print(f"4) yasb_json = {yasb_json}")
         yasb_json = json.dumps(yasb_json) # convert single quotes to double quotes
-        print(f"5) yasb_json = {yasb_json})
+        print(f"5) yasb_json = {yasb_json}")
         yasb_dict = json.loads(yasb_json) # convert JSON to python object
-        print(f"6) yasb_dict = {yasb_dict})
+        print(f"6) yasb_dict = {yasb_dict}")
         #############
         for key, value in yasb_dict.items(): # add embed title with list name as hyperlink
             if key in ["name"]:

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -1,4 +1,9 @@
 """main bot file witt slash commands and events"""
+# https://stackoverflow.com/a/65908383
+# fixes libgcc_s.so.1 must be installed for pthread_cancel to work
+import ctypes
+libgcc_s = ctypes.CDLL('libgcc_s.so.1')
+
 import os
 # import subprocess
 from datetime import date

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -247,24 +247,24 @@ async def on_message(message):
 
         # convert YASB link to XWS
         yasb_link = message.content
-        print(f"1) yasb_link = {yasb_link}")
+        #print(f"1) yasb_link = {yasb_link}")
         yasb_convert = yasb_link.replace(
             '://xwing-legacy.com/',
             '://squad2xws.herokuapp.com/yasb/xws'
         )
-        print(f"2) yasb_convert = {yasb_convert}")
+        #print(f"2) yasb_convert = {yasb_convert}")
         yasb_xws = requests.get(yasb_convert, timeout=10)
-        print(f"3) yasb_xws = {yasb_xws}")
+        #print(f"3) yasb_xws = {yasb_xws}")
         #############
         # don't know if it works at all???
         #yasb_xws = unescape(yasb_xws) # delete all characters which prevents proper parsing
 
         yasb_json = yasb_xws.json() # raw XWS in JSON
-        print(f"4) yasb_json = {yasb_json}")
+        #print(f"4) yasb_json = {yasb_json}")
         yasb_json = json.dumps(yasb_json) # convert single quotes to double quotes
-        print(f"5) yasb_json = {yasb_json}")
+        #print(f"5) yasb_json = {yasb_json}")
         yasb_dict = json.loads(yasb_json) # convert JSON to python object
-        print(f"6) yasb_dict = {yasb_dict}")
+        #print(f"6) yasb_dict = {yasb_dict}")
         #############
         for key, value in yasb_dict.items(): # add embed title with list name as hyperlink
             if key in ["name"]:
@@ -274,11 +274,11 @@ async def on_message(message):
                     url=message.content,
                     description="YASB Legacy 2.0 list"
                 )
-        try:
+        try: # use custom name for squads with default name from yasb
             embed
         except NameError:
             embed = discord.Embed(
-                title="Infamous squadron",
+                title="Infamous Squadron",
                 colour=discord.Colour.random(),
                 url=message.content,
                 description="YASB Legacy 2.0 list"

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -247,19 +247,24 @@ async def on_message(message):
 
         # convert YASB link to XWS
         yasb_link = message.content
+        print(f"1) yasb_link = {yasb_link})
         yasb_convert = yasb_link.replace(
             '://xwing-legacy.com/',
             '://squad2xws.herokuapp.com/yasb/xws'
         )
+        print(f"2) yasb_convert = {yasb_convert})
         yasb_xws = requests.get(yasb_convert, timeout=10)
-
+        print(f"3) yasb_xws = {yasb_xws})
         #############
         # don't know if it works at all???
         #yasb_xws = unescape(yasb_xws) # delete all characters which prevents proper parsing
 
         yasb_json = yasb_xws.json() # raw XWS in JSON
+        print(f"4) yasb_json = {yasb_json})
         yasb_json = json.dumps(yasb_json) # convert single quotes to double quotes
+        print(f"5) yasb_json = {yasb_json})
         yasb_dict = json.loads(yasb_json) # convert JSON to python object
+        print(f"6) yasb_dict = {yasb_dict})
         #############
         for key, value in yasb_dict.items(): # add embed title with list name as hyperlink
             if key in ["name"]:

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -273,8 +273,8 @@ async def on_message(message):
                     colour=discord.Colour.random(),
                     url=message.content,
                     description="YASB Legacy 2.0 list"
-            else:
-               embed = discord.Embed(
+            else :
+                embed = discord.Embed(
                     title="Infamous squadron",
                     colour=discord.Colour.random(),
                     url=message.content,

--- a/elobot/main.py
+++ b/elobot/main.py
@@ -274,8 +274,9 @@ async def on_message(message):
                     url=message.content,
                     description="YASB Legacy 2.0 list"
                 )
-
-        if not embed:
+        try:
+            embed
+        except NameError:
             embed = discord.Embed(
                 title="Infamous squadron",
                 colour=discord.Colour.random(),


### PR DESCRIPTION
Bot fails to convert yasb link with %20 space in adress (example http://xwing-legacy.com/?f=Separatist%20Alliance&d=v8ZsZ200Z426XWWWWWW&sn=New%20Squadron&obs=)

commented unescape so it wont delete characters